### PR TITLE
Host header overwrite issue

### DIFF
--- a/src/main/java/com/archerizer/experiments/micronaut/GreetingApi.java
+++ b/src/main/java/com/archerizer/experiments/micronaut/GreetingApi.java
@@ -7,10 +7,6 @@ import io.micronaut.http.annotation.Produces;
 
 @Controller("/greeting")
 public class GreetingApi {
-    // GET /greeting/robyn
-    // {
-    //     "message": "robyn"
-    // }
     @Get("/{message}")
     @Produces(MediaType.APPLICATION_JSON)
     Greeting getGreeting(String message) {

--- a/src/main/java/com/archerizer/experiments/micronaut/issue/host/HeaderApi.java
+++ b/src/main/java/com/archerizer/experiments/micronaut/issue/host/HeaderApi.java
@@ -1,0 +1,25 @@
+package com.archerizer.experiments.micronaut.issue.host;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Header;
+import io.micronaut.http.annotation.Produces;
+
+import java.util.Optional;
+
+@Controller("/headers")
+public class HeaderApi {
+
+    @Get("/host")
+    @Produces(MediaType.TEXT_PLAIN)
+    String hostResponse(@Header("Host") String hostHeader) {
+        return Optional.ofNullable(hostHeader).orElse("No host header!");
+    }
+
+    @Get("/notHost")
+    @Produces(MediaType.TEXT_PLAIN)
+    String noHostResponse(@Header("header") String header) {
+        return Optional.ofNullable(header).orElse("No header!");
+    }
+}

--- a/src/test/java/com/archerizer/experiments/micronaut/issue/host/HeaderApiTest.java
+++ b/src/test/java/com/archerizer/experiments/micronaut/issue/host/HeaderApiTest.java
@@ -1,0 +1,55 @@
+package com.archerizer.experiments.micronaut.issue.host;
+
+import io.micronaut.context.ApplicationContext;
+import io.micronaut.http.HttpRequest;
+import io.micronaut.http.client.HttpClient;
+import io.micronaut.runtime.server.EmbeddedServer;
+import org.junit.jupiter.api.*;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.TestInstance.Lifecycle.PER_CLASS;
+
+@TestInstance(PER_CLASS)
+@DisplayName("host header Api tests")
+class HeaderApiTest {
+
+    protected EmbeddedServer server;
+
+    protected HttpClient client;
+
+    @BeforeAll
+    void setupServerAndClient() {
+        server = ApplicationContext.run(EmbeddedServer.class);
+        client = HttpClient.create(server.getURL());
+    }
+
+    @AfterAll
+    void shutdownServer() {
+        server.close();
+        client.close();
+    }
+
+    @Test
+    @DisplayName("Returns header value as robyn")
+    void returnsRequestedHeader() throws IOException {
+
+        var request = HttpRequest.GET("/headers/notHost").header("header", "robyn");
+
+        var response = client.toBlocking().exchange(request, String.class).body();
+
+        assertThat(response).isEqualTo("robyn");
+    }
+
+    @Test
+    @DisplayName("Returns Host header value as robyn")
+    void returnsRequestedHostHeader() throws IOException {
+
+        var request = HttpRequest.GET("/headers/host").header("Host", "robyn");
+
+        var response = client.toBlocking().exchange(request, String.class).body();
+
+        assertThat(response).isEqualTo("robyn");
+    }
+}


### PR DESCRIPTION
When executing a GET request with a custom Host header value using Micronaut as the client, Micronaut overwrites it with the default.